### PR TITLE
Fix PROV import

### DIFF
--- a/ontology/miapa.owl
+++ b/ontology/miapa.owl
@@ -40,8 +40,8 @@
 This ontology is maintained at http://github.com/miapa/miapa, and requests for changes or additions should be filed at the issue tracker there. The discussion list is at miapa-discuss@googlegroups.com. Further resources about MIAPA can be found at the project&apos;s main page at http://evoio.org/wiki/MIAPA.</dc:description>
         <dc:creator>Hilmar Lapp</dc:creator>
         <owl:imports rdf:resource="&obo;cdao.owl"/>
-        <owl:versionIRI rdf:resource="&obo;miapa/2013-02-01/miapa.owl"/>
-        <owl:imports rdf:resource="http://www.w3.org/ns/prov#"/>
+        <owl:versionIRI rdf:resource="&obo;miapa/2017-TODO-TODO/miapa.owl"/>
+        <owl:imports rdf:resource="http://www.w3.org/ns/prov-o"/>
     </owl:Ontology>
     
 

--- a/ontology/miapa.owl
+++ b/ontology/miapa.owl
@@ -40,7 +40,6 @@
 This ontology is maintained at http://github.com/miapa/miapa, and requests for changes or additions should be filed at the issue tracker there. The discussion list is at miapa-discuss@googlegroups.com. Further resources about MIAPA can be found at the project&apos;s main page at http://evoio.org/wiki/MIAPA.</dc:description>
         <dc:creator>Hilmar Lapp</dc:creator>
         <owl:imports rdf:resource="&obo;cdao.owl"/>
-        <owl:versionIRI rdf:resource="&obo;miapa/2017-TODO-TODO/miapa.owl"/>
         <owl:imports rdf:resource="http://www.w3.org/ns/prov-o"/>
     </owl:Ontology>
     


### PR DESCRIPTION
The simpler http://www.w3.org/ns/prov-o import (aka http://www.w3.org/ns/prov-o.ttl or http://www.w3.org/ns/prov-o.rdf after content negotation) is preferred to http://www.w3.org/ns/prov#. See also #25.

Note that I left the `owl:versionIRI` as `TODO` as it would no longer be 2013-02-01 - however OBO redirects straight to master rather than a tag/commit - so accepting this PR would 'break' OBO.