### PR TITLE
treatment of gap characters

### DIFF
--- a/checklist/MIAPA-checklist.md
+++ b/checklist/MIAPA-checklist.md
@@ -42,7 +42,7 @@ The Checklist
       * whether alignment was manually corrected or edited
    * Tree inference method
       * name of software used, version of program
-      * parameters used, including model of evolution, and optimality criterion
+      * parameters used, including model of evolution, optimality criterion, and treatment of 'gap' characters
       * character weights if (normally then morphological) characters were weighted. (Typically, inference programs provide these in their log files, and thus the information could be copied from there.)
 
 FAQ


### PR DESCRIPTION
The matrix itself may well contain gap characters after alignment. The analysis isn't reproducible if you don't know how these gaps were treated in the tree inference stage, and the effects between different treatments can often be non-trivial. The treatment can't be inferred simply from looking at the matrix or software used in most cases.

If it's judged not "important enough" then fine. But I thought I'd propose it here anyhow. 

Has it been been discussed for inclusion before? Apologies if it has.